### PR TITLE
Add LookInside debug server

### DIFF
--- a/Example/AuroraGlow.xcodeproj/project.pbxproj
+++ b/Example/AuroraGlow.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5097BFEE2E9CB877008E9F0C /* ColorfulX in Frameworks */ = {isa = PBXBuildFile; productRef = 5097BFED2E9CB877008E9F0C /* ColorfulX */; };
+		CCB8669C500051996366FB07 /* LookInsideServer in Frameworks */ = {isa = PBXBuildFile; productRef = 052B13E1C750303DE00487BA /* LookInsideServer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -17,6 +18,8 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		5097BFDD2E9CB83C008E9F0C /* AuroraGlow */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = AuroraGlow;
 			sourceTree = "<group>";
 		};
@@ -28,6 +31,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5097BFEE2E9CB877008E9F0C /* ColorfulX in Frameworks */,
+				CCB8669C500051996366FB07 /* LookInsideServer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,6 +75,7 @@
 			name = AuroraGlow;
 			packageProductDependencies = (
 				5097BFED2E9CB877008E9F0C /* ColorfulX */,
+				052B13E1C750303DE00487BA /* LookInsideServer */,
 			);
 			productName = AuroraGlow;
 			productReference = 5097BFDB2E9CB83C008E9F0C /* AuroraGlow.app */;
@@ -102,6 +107,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				5097BFEC2E9CB877008E9F0C /* XCRemoteSwiftPackageReference "ColorfulX" */,
+				87E8F135AB4C13D51FD1531D /* XCRemoteSwiftPackageReference "LookInside-Release" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5097BFDC2E9CB83C008E9F0C /* Products */;
@@ -299,6 +305,10 @@
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
+				EXCLUDED_SOURCE_FILE_NAMES = (
+					"$(inherited)",
+					"LookInsideServer*",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMainStoryboardFile = Main;
@@ -352,9 +362,22 @@
 				minimumVersion = 6.0.1;
 			};
 		};
+		87E8F135AB4C13D51FD1531D /* XCRemoteSwiftPackageReference "LookInside-Release" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/LookInsideApp/LookInside-Release.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		052B13E1C750303DE00487BA /* LookInsideServer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 87E8F135AB4C13D51FD1531D /* XCRemoteSwiftPackageReference "LookInside-Release" */;
+			productName = LookInsideServer;
+		};
 		5097BFED2E9CB877008E9F0C /* ColorfulX */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5097BFEC2E9CB877008E9F0C /* XCRemoteSwiftPackageReference "ColorfulX" */;

--- a/Example/ColorfulApp.xcodeproj/project.pbxproj
+++ b/Example/ColorfulApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		50C6638A2B19B04800AF7053 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C663892B19B04800AF7053 /* ContentView.swift */; };
 		50C6638C2B19B04900AF7053 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50C6638B2B19B04900AF7053 /* Assets.xcassets */; };
 		50C663982B19B07B00AF7053 /* ColorfulX in Frameworks */ = {isa = PBXBuildFile; productRef = 50C663972B19B07B00AF7053 /* ColorfulX */; };
+		AB635E33E1363BB06A46CBC7 /* LookInsideServer in Frameworks */ = {isa = PBXBuildFile; productRef = 5FA5607E41469997D6F0C8F9 /* LookInsideServer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50C663982B19B07B00AF7053 /* ColorfulX in Frameworks */,
+				AB635E33E1363BB06A46CBC7 /* LookInsideServer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -104,6 +106,7 @@
 			name = ColorfulApp;
 			packageProductDependencies = (
 				50C663972B19B07B00AF7053 /* ColorfulX */,
+				5FA5607E41469997D6F0C8F9 /* LookInsideServer */,
 			);
 			productName = ColorfulApp;
 			productReference = 50C663842B19B04800AF7053 /* ColorfulApp.app */;
@@ -133,6 +136,9 @@
 				Base,
 			);
 			mainGroup = 50C6637B2B19B04800AF7053;
+			packageReferences = (
+				42EDFA54E4C4296DDEB9A902 /* XCRemoteSwiftPackageReference "LookInside-Release" */,
+			);
 			productRefGroup = 50C663852B19B04800AF7053 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -349,6 +355,10 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = NO;
+				EXCLUDED_SOURCE_FILE_NAMES = (
+					"$(inherited)",
+					"LookInsideServer*",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Colorful;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -403,10 +413,26 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		42EDFA54E4C4296DDEB9A902 /* XCRemoteSwiftPackageReference "LookInside-Release" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/LookInsideApp/LookInside-Release.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		50C663972B19B07B00AF7053 /* ColorfulX */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ColorfulX;
+		};
+		5FA5607E41469997D6F0C8F9 /* LookInsideServer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 42EDFA54E4C4296DDEB9A902 /* XCRemoteSwiftPackageReference "LookInside-Release" */;
+			productName = LookInsideServer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Bug reports and pull requests are welcome on GitHub issues. When contributing:
 ## License
 
 ColorfulX is released under the MIT License. See [LICENSE](LICENSE).
+
 ## Sponsor
 
 [LookInside](https://lookinside-app.com/) helps you inspect a running iOS or macOS app UI from your Mac.

--- a/README.md
+++ b/README.md
@@ -218,3 +218,6 @@ Bug reports and pull requests are welcome on GitHub issues. When contributing:
 ## License
 
 ColorfulX is released under the MIT License. See [LICENSE](LICENSE).
+## Sponsor
+
+[LookInside](https://lookinside-app.com/) helps you inspect a running iOS or macOS app UI from your Mac.


### PR DESCRIPTION
## What changed

- Add the LookInside-Release Swift package and link the LookInsideServer product into the app target.
- Exclude LookInsideServer from Release builds with `EXCLUDED_SOURCE_FILE_NAMES = $(inherited) LookInsideServer*`.
- Add the LookInside sponsor block to the root README.

## Validation

- Debug build passes.
- Release build passes.
- Debug artifact contains LookInsideServer.
- Release artifact excludes LookInsideServer.
